### PR TITLE
Add `--without-lua_resty_limit_traffic` to openresty compile flags

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,7 +69,8 @@ default['openresty']['source']['default_configure_flags'] = [
   '--without-http_ssi_module',
   '--without-mail_smtp_module',
   '--without-mail_imap_module',
-  '--without-mail_pop3_module'
+  '--without-mail_pop3_module',
+  '--without-lua_resty_limit_traffic'
 ]
 
 # Default compile-in modules


### PR DESCRIPTION
We are deploying custom version of lua resty limit script